### PR TITLE
fix: lit-infinite-viewer has sideeffects

### DIFF
--- a/packages/lit-infinite-viewer/package.json
+++ b/packages/lit-infinite-viewer/package.json
@@ -4,7 +4,6 @@
     "types": "declaration/index.d.ts",
     "main": "dist/infinite-viewer.cjs.js",
     "module": "dist/infinite-viewer.esm.js",
-    "sideEffects": false,
     "keywords": [
         "select",
         "infinite-viewer",


### PR DESCRIPTION
The @customElement("lit-infinite-viewer") has the side-effect of registering the lit-infinite-viewer with the custom element registry. Therefore it cannot be tree-shaken.