### PR TITLE
chore: upgrade lit

### DIFF
--- a/packages/lit-infinite-viewer/demo/index.ts
+++ b/packages/lit-infinite-viewer/demo/index.ts
@@ -1,5 +1,4 @@
-import { html } from "lit-element";
-import { render } from "lit-html";
+import { html, render } from "lit";
 import "../src/LitInfiniteViewer";
 
 render(html`

--- a/packages/lit-infinite-viewer/package.json
+++ b/packages/lit-infinite-viewer/package.json
@@ -33,7 +33,7 @@
     ],
     "devDependencies": {
         "@daybrush/builder": "^0.1.2",
-        "lit-element": "^2.2.1",
+        "lit": "^2.7.0 || ^3.0.0",
         "typescript": "^4.5.0 <4.6.0"
     },
     "dependencies": {

--- a/packages/lit-infinite-viewer/src/LitInfiniteViewer.ts
+++ b/packages/lit-infinite-viewer/src/LitInfiniteViewer.ts
@@ -1,4 +1,5 @@
-import { LitElement, html, customElement, property } from "lit-element";
+import { LitElement, html } from "lit";
+import {customElement, property} from 'lit/decorators.js';
 import VanillaInfiniteViewer, {
     InfiniteViewerOptions,
     EVENTS, PROPERTIES, InfiniteViewerMethods, METHODS, OPTIONS


### PR DESCRIPTION
Lit v3 has been released. It is vastly compatibly with Lit v2. Some small changes were necessary (e.g. decorators should be imported from lit/decorators.js instead of lit-element).

Unfortunately, when I try to `npm run build` I run into the following error:

```
./src/index.ts → ./dist/infinite-viewer.umd.js...
(!) Error when using sourcemap for reporting an error: Can't resolve original location of error.
../../node_modules/lit-element/lit-element.js: (6:195)
[!] Error: Unexpected token
../../node_modules/lit-element/lit-element.js (6:195)
4:  * Copyright 2017 Google LLC
5:  * SPDX-License-Identifier: BSD-3-Clause
6:  */class s extends t{constructor(){super(...arguments),this.renderOptions={host:this},this._$Do=void 0}createRenderRoot(){const t=super.createRenderRoot();return this.renderOptions.renderBefore??=t.firstChild,t}update(t){const i=this.render(); // I shortened this
                                                                                                                                                                                                      ^
7: //# sourceMappingURL=lit-element.js.map
Error: Unexpected token
    at error (/home/schoenbrod/Code/infinite-viewer/node_modules/rollup/dist/shared/node-entry.js:5400:30)
    at Module.error (/home/schoenbrod/Code/infinite-viewer/node_modules/rollup/dist/shared/node-entry.js:9824:16)
```
It looks like ??= is an unexpected token. However, this token is valid since node v15.
I'm running node v20.8.1
```
node -v
v20.8.1
```
Do you have any thoughts on this?