### PR TITLE
fix: fix the the 'getViewportHeight' method returns incorrect values

### DIFF
--- a/packages/infinite-viewer/src/InfiniteViewerManager.tsx
+++ b/packages/infinite-viewer/src/InfiniteViewerManager.tsx
@@ -402,7 +402,7 @@ class InfiniteViewer extends EventEmitter<InfiniteViewerEvents> {
         return this.viewportWidth;
     }
     public getViewportHeight() {
-        return this.viewportWidth;
+        return this.viewportHeight;
     }
     public getViewportScrollWidth() {
         return this.viewportScrollWidth;


### PR DESCRIPTION
I discovered that the 'getViewportHeight' method returns incorrect values, so I made the necessary modifications and submitted a PR.