### PR TITLE
feat: add auto as usePinchKey to automatically pinch with wheel

### DIFF
--- a/packages/infinite-viewer/src/InfiniteViewerManager.tsx
+++ b/packages/infinite-viewer/src/InfiniteViewerManager.tsx
@@ -863,7 +863,7 @@ class InfiniteViewer extends EventEmitter<InfiniteViewerEvents> {
         const pinchDirection = options.pinchDirection;
         const maxPinchWheel = options.maxPinchWheel || Infinity;
 
-        const isKeydown = e[`${this.wheelPinchKey}Key`] || e.ctrlKey;
+        const isKeydown = this.wheelPinchKey === 'auto' ? true : e[`${this.wheelPinchKey}Key`] || e.ctrlKey;
 
         if (options.useWheelPinch && isKeydown) {
             let deltaY = e.deltaY;

--- a/packages/infinite-viewer/src/InfiniteViewerManager.tsx
+++ b/packages/infinite-viewer/src/InfiniteViewerManager.tsx
@@ -863,7 +863,7 @@ class InfiniteViewer extends EventEmitter<InfiniteViewerEvents> {
         const pinchDirection = options.pinchDirection;
         const maxPinchWheel = options.maxPinchWheel || Infinity;
 
-        const isKeydown = this.wheelPinchKey === 'auto' ? true : e[`${this.wheelPinchKey}Key`] || e.ctrlKey;
+        const isKeydown = this.wheelPinchKey === null ? true : e[`${this.wheelPinchKey}Key`] || e.ctrlKey;
 
         if (options.useWheelPinch && isKeydown) {
             let deltaY = e.deltaY;

--- a/packages/infinite-viewer/src/types.ts
+++ b/packages/infinite-viewer/src/types.ts
@@ -84,10 +84,10 @@ export interface InfiniteViewerOptions {
      */
     useWheelPinch: boolean;
     /**
-     * Key to use wheel pinch
+     * Key to use wheel pinch. Null if you want wheel pinch without any key.
      * @default "ctrl"
      */
-    wheelPinchKey: "ctrl" | "meta" | "alt" | "shift" | "auto";
+    wheelPinchKey: "ctrl" | "meta" | "alt" | "shift" | null,
     /**
      * Whether to use wheel scroll. You can scroll smoothly by using the wheel.
      * @default IS_SAFARI

--- a/packages/infinite-viewer/src/types.ts
+++ b/packages/infinite-viewer/src/types.ts
@@ -87,7 +87,7 @@ export interface InfiniteViewerOptions {
      * Key to use wheel pinch
      * @default "ctrl"
      */
-    wheelPinchKey: "ctrl" | "meta" | "alt" | "shift",
+    wheelPinchKey: "ctrl" | "meta" | "alt" | "shift" | "auto";
     /**
      * Whether to use wheel scroll. You can scroll smoothly by using the wheel.
      * @default IS_SAFARI


### PR DESCRIPTION
**Feature description:**
You can use `wheelPinchKey=null` to indicate you want the wheelPinch to be used by default to zoom in or out. Usually used when the infinite viewer is navigated on the x,y axis by clicking and dragging the mouse.